### PR TITLE
Add `has_parallel_download` feature to detect if rctx.download supports parallel downloads

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -37,6 +37,9 @@ _flags = struct(
 _rules = struct(
     # Whether TemplateDict#add_joined allows the map_each callback to return a list of strings (#17306)
     template_dict_map_each_can_return_list = ge("6.1.0"),
+
+    # Whether repository_ctx#download has the block parameter, allowing parallel downloads
+    has_parallel_download = ge("7.1.0")
 )
 
 _toolchains = struct(


### PR DESCRIPTION
Coming in 7.1.0, [repository_ctx#download](https://bazel.build/rules/lib/builtins/repository_ctx#download) has a new argument, block:

> If set to false, the call returns immediately and instead of the regular return value, it returns a token with one single method, wait(), which blocks until the download is finished and returns the usual return value or throws as usual.

It would be useful to be able to update repository rules to use this feature when available.


