### PR TITLE
Add download_has_headers_param feature

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -25,6 +25,9 @@ _external_deps = struct(
     module_extension_has_os_arch_dependent = ge("6.4.0"),
     # Whether repository_ctx#download has the block parameter, allowing parallel downloads (#19674)
     download_has_block_param = ge("7.1.0")
+    # Whether repository_ctx#download has the headers parameter, allowing arbitrary headers (#17829)
+    download_has_headers_param = ge("7.1.0")
+
 )
 
 _flags = struct(


### PR DESCRIPTION
Coming in 7.1.0, rctx.download will support arbitrary headers.